### PR TITLE
feat: Use read-only file system and securityContext

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ make container
    $ helm install harbor-scanner-aqua ./helm/harbor-scanner-aqua \
                   --namespace harbor \
                   --set image.tag=dev \
+                  --set scanner.logLevel=trace \
                   --set scanner.aqua.user=$AQUA_USER \
                   --set scanner.aqua.password=$AQUA_PASSWORD \
                   --set scanner.aqua.host=http://csp-console-svc.aqua:8080
@@ -114,6 +115,7 @@ Configuration of the adapter is done via environment variables at startup.
 | `SCANNER_AQUA_PASSWORD`       | N/A      | Aqua management console password (required)                               |
 | `SCANNER_AQUA_HOST`           | `http://aqua-web.aqua-security:8080` | Aqua management console address               |
 | `SCANNER_AQUA_REGISTRY`       | `Harbor` | The name of the Harbor registry configured in Aqua management console     |
+| `SCANNER_AQUA_REPORTS_DIR`    | `/var/lib/scanner/reports` | Directory to save temporary scan reports                |
 
 ## License
 

--- a/helm/harbor-scanner-aqua/README.md
+++ b/helm/harbor-scanner-aqua/README.md
@@ -82,6 +82,7 @@ The following table lists the configurable parameters of the scanner adapter cha
 | `scanner.aqua.password`      | Aqua management console password (required)                             | N/A            |
 | `scanner.aqua.host`          | Aqua management console address                                         | `http://aqua-web.aqua-security:8080` |
 | `scanner.aqua.registry`      | The name of the Harbor registry configured in Aqua management console   | `Harbor`       |
+| `scanner.aqua.reportsDir`    | Directory to save temporary scan reports                                | `/var/lib/scanner/reports` |
 | `scanner.api.tlsEnabled`     | The flag to enable or disable TLS for HTTP                              | `true`         |
 | `scanner.api.tlsCertificate` | The absolute path to the x509 certificate file                          |                |
 | `scanner.api.tlsKey`         | The absolute path to the x509 private key file                          |                |

--- a/helm/harbor-scanner-aqua/templates/deployment.yaml
+++ b/helm/harbor-scanner-aqua/templates/deployment.yaml
@@ -21,8 +21,10 @@ spec:
           image: {{ template "harbor-scanner-aqua.imageRef" . }}
           imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
           securityContext:
+            privileged: false
             runAsUser: 1000
             runAsNonRoot: true
+            readOnlyRootFilesystem: true
           env:
             - name: "SCANNER_LOG_LEVEL"
               value: {{ .Values.scanner.logLevel }}
@@ -45,9 +47,11 @@ spec:
                   name: {{ include "harbor-scanner-aqua.fullname" . }}
                   key: aqua_password
             - name: "SCANNER_AQUA_HOST"
-              value: {{ .Values.scanner.aqua.host }}
+              value: {{ .Values.scanner.aqua.host | quote }}
             - name: "SCANNER_AQUA_REGISTRY"
-              value: {{ .Values.scanner.aqua.registry }}
+              value: {{ .Values.scanner.aqua.registry | quote }}
+            - name: "SCANNER_AQUA_REPORTS_DIR"
+              value: {{ .Values.scanner.aqua.reportsDir | quote }}
             {{- if .Values.scanner.api.tlsEnabled }}
             - name: "SCANNER_API_TLS_CERTIFICATE"
               value: "/certs/tls.crt"
@@ -58,12 +62,17 @@ spec:
             - name: api-server
               containerPort: {{ .Values.service.port }}
           volumeMounts:
+            - name: data
+              mountPath: /var/lib/scanner/reports
+              readOnly: false
             {{- if .Values.scanner.api.tlsEnabled }}
-            - mountPath: /certs
-              name: certs
+            - name: certs
+              mountPath: /certs
               readOnly: true
             {{- end }}
       volumes:
+        - name: data
+          emptyDir: {}
         {{- if .Values.scanner.api.tlsEnabled }}
         - name: certs
           secret:

--- a/helm/harbor-scanner-aqua/values.yaml
+++ b/helm/harbor-scanner-aqua/values.yaml
@@ -27,3 +27,4 @@ scanner:
     password: ""
     host: "http://aqua-web.aqua-security:8080"
     registry: "Harbor"
+    reportsDir: "/var/lib/scanner/reports"

--- a/pkg/app.go
+++ b/pkg/app.go
@@ -28,6 +28,14 @@ func Run(info etc.BuildInfo) error {
 		return xerrors.Errorf("getting config: %w", err)
 	}
 
+	if _, err := os.Stat(config.AquaCSP.ReportsDir); os.IsNotExist(err) {
+		log.WithField("path", config.AquaCSP.ReportsDir).Debug("Creating reports dir")
+		err = os.MkdirAll(config.AquaCSP.ReportsDir, os.ModeDir)
+		if err != nil {
+			return xerrors.Errorf("creating reports dir: %w", err)
+		}
+	}
+
 	workPool := work.New()
 	command := aqua.NewCommand(config.AquaCSP)
 	transformer := scanner.NewTransformer(clock.NewSystemClock())

--- a/pkg/etc/config.go
+++ b/pkg/etc/config.go
@@ -45,7 +45,7 @@ type AquaCSP struct {
 	Password   string `env:"SCANNER_AQUA_PASSWORD"`
 	Host       string `env:"SCANNER_AQUA_HOST" envDefault:"http://aqua-web.aqua-security:8080"`
 	Registry   string `env:"SCANNER_AQUA_REGISTRY" envDefault:"Harbor"`
-	ReportsDir string `env:"SCANNER_AQUA_REPORTS_DIR" envDefault:"/tmp/reports"`
+	ReportsDir string `env:"SCANNER_AQUA_REPORTS_DIR" envDefault:"/var/lib/scanner/reports"`
 }
 
 type Store struct {
@@ -61,15 +61,6 @@ func GetConfig() (cfg Config, err error) {
 	if err != nil {
 		return cfg, xerrors.Errorf("parsing config: %w", err)
 	}
-
-	if _, err := os.Stat(cfg.AquaCSP.ReportsDir); os.IsNotExist(err) {
-		log.WithField("path", cfg.AquaCSP.ReportsDir).Debug("Creating reports dir")
-		err = os.MkdirAll(cfg.AquaCSP.ReportsDir, os.ModeDir)
-		if err != nil {
-			return cfg, xerrors.Errorf("creating reports dir: %w", err)
-		}
-	}
-
 	return
 }
 

--- a/pkg/etc/config_test.go
+++ b/pkg/etc/config_test.go
@@ -32,7 +32,7 @@ func TestGetConfig(t *testing.T) {
 					Password:   "",
 					Host:       "http://aqua-web.aqua-security:8080",
 					Registry:   "Harbor",
-					ReportsDir: "/tmp/reports",
+					ReportsDir: "/var/lib/scanner/reports",
 				},
 				Store: Store{
 					RedisURL:      "redis://harbor-harbor-redis:6379",
@@ -52,6 +52,7 @@ func TestGetConfig(t *testing.T) {
 				"SCANNER_API_READ_TIMEOUT":    "1h",
 				"SCANNER_API_WRITE_TIMEOUT":   "2m",
 				"SCANNER_API_IDLE_TIMEOUT":    "1h2m3s",
+				"SCANNER_AQUA_REPORTS_DIR":    "/somewhere/else",
 			},
 			expectedConfig: Config{
 				API: API{
@@ -67,7 +68,7 @@ func TestGetConfig(t *testing.T) {
 					Password:   "",
 					Host:       "http://aqua-web.aqua-security:8080",
 					Registry:   "Harbor",
-					ReportsDir: "/tmp/reports",
+					ReportsDir: "/somewhere/else",
 				},
 				Store: Store{
 					RedisURL:      "redis://harbor-harbor-redis:6379",


### PR DESCRIPTION
```
kubectl exec -it harbor-scanner-aqua-7f9d6f597-6jdrn sh
/ $ ps
PID   USER     TIME  COMMAND
    1 scanner   0:00 scanner-adapter
   42 scanner   0:00 sh
   48 scanner   0:00 ps
/ $ id
uid=1000(scanner) gid=1000(scanner)
/ $ touch /var/lib/test
touch: /var/lib/test: Read-only file system
```