### PR TITLE
chore: Add init container to download scannercli

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -30,8 +30,6 @@ dockers:
       - "docker.io/aquasec/harbor-scanner-aqua:{{ .Version }}"
     binaries:
       - scanner-adapter
-    extra_files:
-      - scannercli
     build_flag_templates:
       - "--label=org.label-schema.schema-version=1.0"
       - "--label=org.label-schema.name={{ .ProjectName }}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,6 @@ FROM alpine:3
 
 RUN adduser -u 1000 -D -g '' scanner scanner
 
-COPY scannercli /usr/local/bin/scannercli
 COPY scanner-adapter /usr/local/bin/scanner-adapter
 
 USER scanner

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ for providing vulnerability reports on images stored in Harbor registry as part 
 
 ## Requirements
 
-This adapter requires Aqua CSP 4.5 deployment to operate against. The adapter can be deployed before the Aqua CSP
+This adapter requires Aqua CSP >= 4.5 deployment to operate against. The adapter can be deployed before the Aqua CSP
 installation, but the Aqua CSP management console URL and credentials must be known to configure the adapter with
 the environment variables.
 
@@ -68,8 +68,8 @@ is translated to the following `scannercli` command:
 
 ```
 $ scannercli scan \
-    --user $AQUA_SCANNER_USER \
-    --password $AQUA_SCANNER_PASSWORD \
+    --user $AQUA_CONSOLE_USERNAME \
+    --password $AQUA_CONSOLE_PASSWORD \
     --host http://csp-console-svc.aqua:8080 \
     --registry "Harbor" \
     library/mongo:3.4-xenial
@@ -116,10 +116,14 @@ make container
    ```
    $ helm install harbor-scanner-aqua ./helm/harbor-scanner-aqua \
                   --namespace harbor \
-                  --set image.tag=dev \
+                  --set aqua.version=4.5 \
+                  --set aqua.registry.server=registry.aquasec.com \
+                  --set aqua.registry.username=$AQUA_REGISTRY_USERNAME \
+                  --set aqua.registry.password=$AQUA_REGISTRY_PASSWORD \
+                  --set scanner.image.tag=dev \
                   --set scanner.logLevel=trace \
-                  --set scanner.aqua.user=$AQUA_USER \
-                  --set scanner.aqua.password=$AQUA_PASSWORD \
+                  --set scanner.aqua.username=$AQUA_CONSOLE_USERNAME \
+                  --set scanner.aqua.password=$AQUA_CONSOLE_PASSWORD \
                   --set scanner.aqua.host=http://csp-console-svc.aqua:8080
    ```
 
@@ -144,8 +148,10 @@ make container
                   --set scanner.api.tlsEnabled=true \
                   --set scanner.api.tlsCertificate="`cat tls.crt`" \
                   --set scanner.api.tlsKey="`cat tls.key`" \
-                  --set scanner.aqua.user=$AQUA_USER \
-                  --set scanner.aqua.password=$AQUA_PASSWORD \
+                  --set aqua.registry.username=$AQUA_REGISTRY_USERNAME \
+                  --set aqua.registry.password=$AQUA_REGISTRY_PASSWORD \
+                  --set scanner.aqua.username=$AQUA_CONSOLE_USERNAME \
+                  --set scanner.aqua.password=$AQUA_CONSOLE_PASSWORD \
                   --set scanner.aqua.host=http://csp-console-svc.aqua:8080
    ```
 3. Configure the scanner adapter in Harbor web console.
@@ -171,7 +177,7 @@ Configuration of the adapter is done via environment variables at startup.
 | `SCANNER_API_READ_TIMEOUT`    | `15s`    | The maximum duration for reading the entire request, including the body   |
 | `SCANNER_API_WRITE_TIMEOUT`   | `15s`    | The maximum duration before timing out writes of the response             |
 | `SCANNER_API_IDLE_TIMEOUT`    | `60s`    | The maximum amount of time to wait for the next request when keep-alives are enabled |
-| `SCANNER_AQUA_USER`           | N/A      | Aqua management console username (required)                               |
+| `SCANNER_AQUA_USERNAME`       | N/A      | Aqua management console username (required)                               |
 | `SCANNER_AQUA_PASSWORD`       | N/A      | Aqua management console password (required)                               |
 | `SCANNER_AQUA_HOST`           | `http://csp-console-svc.aqua:8080` | Aqua management console address                 |
 | `SCANNER_AQUA_REGISTRY`       | `Harbor` | The name of the Harbor registry configured in Aqua management console     |

--- a/helm/harbor-scanner-aqua/Chart.yaml
+++ b/helm/harbor-scanner-aqua/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: harbor-scanner-aqua
-version: 0.1.0
-appVersion: 0.1.1
+version: 0.2.0
+appVersion: 0.2.0
 description: Harbor scanner adapter for Aqua CSP scanner
 keywords:
   - scanner

--- a/helm/harbor-scanner-aqua/README.md
+++ b/helm/harbor-scanner-aqua/README.md
@@ -9,8 +9,12 @@ Aqua CSP Scanner as a plug-in vulnerability scanner in the Harbor registry.
 ```
 $ helm install harbor-scanner-aqua . \
                --namespace harbor \
-               --set scanner.aqua.user=$AQUA_USER \
-               --set scanner.aqua.password=$AQUA_PASSWORD \
+               --set aqua.version=4.5 \
+               --set aqua.registry.server=registry.aquasec.com \
+               --set aqua.registry.username=$AQUA_REGISTRY_USERNAME \
+               --set aqua.registry.password=$AQUA_REGISTRY_PASSWORD \
+               --set scanner.aqua.username=$AQUA_CONSOLE_USERNAME \
+               --set scanner.aqua.password=$AQUA_CONSOLE_PASSWORD \
                --set scanner.aqua.host=http://csp-console-svc.aqua:8080
 ```
 
@@ -33,8 +37,12 @@ $ helm install harbor-scanner-aqua . \
                   --set scanner.api.tlsEnabled=true \
                   --set scanner.api.tlsCertificate="`cat tls.crt`" \
                   --set scanner.api.tlsKey="`cat tls.key`" \
-                  --set scanner.aqua.user=$AQUA_USER \
-                  --set scanner.aqua.password=$AQUA_PASSWORD \
+                  --set aqua.version=4.5 \
+                  --set aqua.registry.server=registry.aquasec.com \
+                  --set aqua.registry.username=$AQUA_REGISTRY_USERNAME \
+                  --set aqua.registry.password=$AQUA_REGISTRY_PASSWORD \
+                  --set scanner.aqua.username=$AQUA_CONSOLE_USERNAME \
+                  --set scanner.aqua.password=$AQUA_CONSOLE_PASSWORD \
                   --set scanner.aqua.host=http://csp-console-svc.aqua:8080
    ```
 
@@ -77,8 +85,16 @@ The following table lists the configurable parameters of the scanner adapter cha
 
 |              Parameter             |                                Description                              |    Default     |
 |------------------------------------|-------------------------------------------------------------------------|----------------|
+| `aqua.version`                     | The version of Aqua CSP that the adapter operates against               | `4.5`          |
+| `aqua.registry.server`             | Aqua Docker registry server                                             | `registry.aquasec.com` |
+| `aqua.registry.username`           | Aqua Docker registry username                                           | N/A            |
+| `aqua.registry.password`           | Aqua Docker registry password                                           | N/A            |
+| `scanner.image.registry`           | Image registry                                                          | `docker.io`    |
+| `scanner.image.repository`         | Image name                                                              | `aquasec/harbor-scanner-aqua` |
+| `scanner.image.tag`                | Image tag                                                               | `{TAG_NAME}`   |
+| `scanner.image.pullPolicy`         | Image pull policy                                                       | `IfNotPresent` |
 | `scanner.logLevel`                 | The log level of `trace`, `debug`, `info`, `warn`, `warning`, `error`, `fatal` or `panic`. The standard logger logs entries with that level or anything above it | `info` |
-| `scanner.aqua.user`                | Aqua management console username (required)                             | N/A            |
+| `scanner.aqua.username`            | Aqua management console username (required)                             | N/A            |
 | `scanner.aqua.password`            | Aqua management console password (required)                             | N/A            |
 | `scanner.aqua.host`                | Aqua management console address                                         | `http://csp-console-svc.aqua:8080` |
 | `scanner.aqua.registry`            | The name of the Harbor registry configured in Aqua management console   | `Harbor`       |
@@ -97,10 +113,6 @@ The following table lists the configurable parameters of the scanner adapter cha
 | `scanner.store.redisScanJobTTL`    | The time to live for persisting scan jobs and associated scan reports   | `1h`           |
 | `service.type`                     | Kubernetes service type                                                 | `LoadBalancer` |
 | `service.port`                     | Kubernetes service port                                                 | `8443`         |
-| `image.registry`                   | Image registry                                                          | `docker.io`    |
-| `image.repository`                 | Image name                                                              | `aquasec/harbor-scanner-aqua` |
-| `image.tag`                        | Image tag                                                               | `{TAG_NAME}`   |
-| `image.pullPolicy`                 | Image pull policy                                                       | `IfNotPresent` |
 | `replicaCount`                     | Number of scanner adapter Pods to run                                   | `1`            |
 
 The above parameters map to the env variables defined in [harbor-scanner-aqua](https://github.com/aquasecurity/harbor-scanner-aqua#configuration).
@@ -110,6 +122,6 @@ Specify each parameter using the `--set key=value[,key=value]` argument to `helm
 ```
 $ helm install my-release . \
                --namespace my-namespace \
-               --set scanner.aqua.user=$AQUA_USER \
-               --set scanner.aqua.password=$AQUA_PASSWORD
+               --set scanner.aqua.username=$AQUA_CONSOLE_USERNAME \
+               --set scanner.aqua.password=$AQUA_CONSOLE_PASSWORD
 ```

--- a/helm/harbor-scanner-aqua/templates/_helpers.tpl
+++ b/helm/harbor-scanner-aqua/templates/_helpers.tpl
@@ -44,11 +44,25 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end -}}
 
 {{/*
-Return the proper imageRef as used by the container template spec.
+Return the proper imageRef as used by the init conainer template spec.
 */}}
-{{- define "harbor-scanner-aqua.imageRef" -}}
-{{- $registryName := .Values.image.registry -}}
-{{- $repositoryName := .Values.image.repository -}}
-{{- $tag := .Values.image.tag | toString -}}
+{{- define "harbor-scanner-aqua.scannerImageRef" -}}
+{{- $registryName := .Values.aqua.registry.server -}}
+{{- $repositoryName := "scanner" -}}
+{{- $tag := .Values.aqua.version | toString -}}
 {{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
 {{- end -}}
+
+{{/*
+Return the proper imageRef as used by the container template spec.
+*/}}
+{{- define "harbor-scanner-aqua.adapterImageRef" -}}
+{{- $registryName := .Values.scanner.image.registry -}}
+{{- $repositoryName := .Values.scanner.image.repository -}}
+{{- $tag := .Values.scanner.image.tag | toString -}}
+{{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
+{{- end -}}
+
+{{- define "imagePullSecret" }}
+{{- printf "{\"auths\": {\"%s\": {\"auth\": \"%s\"}}}" .Values.aqua.registry.server (printf "%s:%s" .Values.aqua.registry.username .Values.aqua.registry.password | b64enc) | b64enc }}
+{{- end }}

--- a/helm/harbor-scanner-aqua/templates/deployment.yaml
+++ b/helm/harbor-scanner-aqua/templates/deployment.yaml
@@ -16,14 +16,33 @@ spec:
         app.kubernetes.io/name: {{ include "harbor-scanner-aqua.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
     spec:
-      containers:
-        - name: main
-          image: {{ template "harbor-scanner-aqua.imageRef" . }}
-          imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
+      imagePullSecrets:
+        - name: {{ include "harbor-scanner-aqua.fullname" . }}-registry
+      securityContext:
+        fsGroup: 1000
+        runAsUser: 1000
+        runAsNonRoot: true
+      initContainers:
+        - name: scannercli
+          image: {{ template "harbor-scanner-aqua.scannerImageRef" . }}
+          imagePullPolicy: {{ .Values.aqua.image.pullPolicy | quote }}
           securityContext:
             privileged: false
-            runAsUser: 1000
-            runAsNonRoot: true
+            readOnlyRootFilesystem: true
+          command:
+            - cp
+          args:
+            - "/opt/aquasec/scannercli"
+            - "/downloads/scannercli"
+          volumeMounts:
+            - name: scannercli
+              mountPath: /downloads
+      containers:
+        - name: main
+          image: {{ template "harbor-scanner-aqua.adapterImageRef" . }}
+          imagePullPolicy: {{ .Values.scanner.image.pullPolicy | quote }}
+          securityContext:
+            privileged: false
             readOnlyRootFilesystem: true
           env:
             - name: "SCANNER_LOG_LEVEL"
@@ -36,11 +55,11 @@ spec:
               value: {{ .Values.scanner.api.writeTimeout }}
             - name: "SCANNER_API_IDLE_TIMEOUT"
               value: {{ .Values.scanner.api.idleTimeout }}
-            - name: "SCANNER_AQUA_USER"
+            - name: "SCANNER_AQUA_USERNAME"
               valueFrom:
                 secretKeyRef:
                   name: {{ include "harbor-scanner-aqua.fullname" . }}
-                  key: aqua_user
+                  key: aqua_username
             - name: "SCANNER_AQUA_PASSWORD"
               valueFrom:
                 secretKeyRef:
@@ -74,6 +93,9 @@ spec:
             - name: api-server
               containerPort: {{ .Values.service.port }}
           volumeMounts:
+            - name: scannercli
+              mountPath: /usr/local/bin/scannercli
+              subPath: scannercli
             - name: data
               mountPath: /var/lib/scanner/reports
               readOnly: false
@@ -86,6 +108,8 @@ spec:
               readOnly: true
             {{- end }}
       volumes:
+        - name: scannercli
+          emptyDir: {}
         - name: data
           emptyDir: {}
         - name: aqua

--- a/helm/harbor-scanner-aqua/templates/secret-registry.yaml
+++ b/helm/harbor-scanner-aqua/templates/secret-registry.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "harbor-scanner-aqua.fullname" . }}-registry
+  labels:
+{{ include "harbor-scanner-aqua.labels" . | indent 4 }}
+type: kubernetes.io/dockerconfigjson
+data:
+  .dockerconfigjson: {{ template "imagePullSecret" . }}

--- a/helm/harbor-scanner-aqua/templates/secret.yaml
+++ b/helm/harbor-scanner-aqua/templates/secret.yaml
@@ -6,5 +6,5 @@ metadata:
 {{ include "harbor-scanner-aqua.labels" . | indent 4 }}
 type: Opaque
 data:
-  aqua_user: {{ required "Aqua user required!" .Values.scanner.aqua.user | b64enc | quote }}
-  aqua_password: {{ required "Aqua password required!" .Values.scanner.aqua.password | b64enc | quote }}
+  aqua_username: {{ required "Aqua username is required!" .Values.scanner.aqua.username | b64enc | quote }}
+  aqua_password: {{ required "Aqua password is required!" .Values.scanner.aqua.password | b64enc | quote }}

--- a/helm/harbor-scanner-aqua/values.yaml
+++ b/helm/harbor-scanner-aqua/values.yaml
@@ -7,13 +7,21 @@ service:
 
 replicaCount: 1
 
-image:
-  registry: "docker.io"
-  repository: "aquasec/harbor-scanner-aqua"
-  tag: "0.1.1"
-  pullPolicy: "IfNotPresent"
+aqua:
+  version: 4.5
+  registry:
+    server: "registry.aquasec.com"
+    username: ""
+    password: ""
+  image:
+    pullPolicy: "IfNotPresent"
 
 scanner:
+  image:
+    registry: "docker.io"
+    repository: "aquasec/harbor-scanner-aqua"
+    tag: "0.2.0"
+    pullPolicy: "IfNotPresent"
   logLevel: info
   api:
     tlsEnabled: false
@@ -23,7 +31,7 @@ scanner:
     writeTimeout: 15s
     idleTimeout: 60s
   aqua:
-    user: ""
+    username: ""
     password: ""
     host: "http://csp-console-svc.aqua:8080"
     registry: "Harbor"

--- a/pkg/aqua/command.go
+++ b/pkg/aqua/command.go
@@ -70,7 +70,7 @@ func (c *command) Exec(imageRef ImageRef) (report ScanReport, err error) {
 
 	args := []string{
 		"scan",
-		"--user", c.cfg.User,
+		"--user", c.cfg.Username,
 		"--password", c.cfg.Password,
 		"--host", c.cfg.Host,
 		"--registry", c.cfg.Registry,

--- a/pkg/etc/config.go
+++ b/pkg/etc/config.go
@@ -41,7 +41,7 @@ func (c API) IsTLSEnabled() bool {
 }
 
 type AquaCSP struct {
-	User        string `env:"SCANNER_AQUA_USER"`
+	Username    string `env:"SCANNER_AQUA_USERNAME"`
 	Password    string `env:"SCANNER_AQUA_PASSWORD"`
 	Host        string `env:"SCANNER_AQUA_HOST" envDefault:"http://csp-console-svc.aqua:8080"`
 	Registry    string `env:"SCANNER_AQUA_REGISTRY" envDefault:"Harbor"`

--- a/pkg/etc/config_test.go
+++ b/pkg/etc/config_test.go
@@ -28,7 +28,7 @@ func TestGetConfig(t *testing.T) {
 					IdleTimeout:  parseDuration(t, "60s"),
 				},
 				AquaCSP: AquaCSP{
-					User:        "",
+					Username:    "",
 					Password:    "",
 					Host:        "http://csp-console-svc.aqua:8080",
 					Registry:    "Harbor",
@@ -56,6 +56,8 @@ func TestGetConfig(t *testing.T) {
 				"SCANNER_AQUA_REPORTS_DIR":    "/somewhere/else",
 				"SCANNER_AQUA_USE_IMAGE_TAG":  "false",
 				"SCANNER_AQUA_HOST":           "http://aqua-web.aqua-security:8080",
+				"SCANNER_AQUA_USERNAME":       "scanner",
+				"SCANNER_AQUA_PASSWORD":       "s3cret",
 			},
 			expectedConfig: Config{
 				API: API{
@@ -67,8 +69,8 @@ func TestGetConfig(t *testing.T) {
 					IdleTimeout:    parseDuration(t, "1h2m3s"),
 				},
 				AquaCSP: AquaCSP{
-					User:        "",
-					Password:    "",
+					Username:    "scanner",
+					Password:    "s3cret",
 					Host:        "http://aqua-web.aqua-security:8080",
 					Registry:    "Harbor",
 					ReportsDir:  "/somewhere/else",


### PR DESCRIPTION
To test it I installed adapters with different versions of scannercli:

```
helm install harbor-scanner-aqua ./helm/harbor-scanner-aqua \
               --namespace harbor \
               --set aqua.version=4.5.19363 \
               --set aqua.registry.server=aquasec.azurecr.io \
               --set aqua.registry.username=$AQUA_REGISTRY_USERNAME \
               --set aqua.registry.password=$AQUA_REGISTRY_PASSWORD \
               --set scanner.image.tag=dev \
               --set scanner.logLevel=trace \
               --set scanner.aqua.username=$AQUA_CONSOLE_USERNAME \
               --set scanner.aqua.password=$AQUA_CONSOLE_PASSWORD \
               --set scanner.aqua.host=http://csp-console-svc.aqua:8080
```

```
helm install harbor-scanner-aqua46rc1 ./helm/harbor-scanner-aqua \
               --namespace harbor \
               --set aqua.version=4.6.rc1 \
               --set aqua.registry.server=aquasec.azurecr.io \
               --set aqua.registry.username=$AQUA_REGISTRY_USERNAME \
               --set aqua.registry.password=$AQUA_REGISTRY_PASSWORD \
               --set scanner.image.tag=dev \
               --set scanner.logLevel=trace \
               --set scanner.aqua.username=$AQUA_CONSOLE_USERNAME \
               --set scanner.aqua.password=$AQUA_CONSOLE_PASSWORD \
               --set scanner.aqua.host=http://csp-console-svc.aqua:8080
```

<img width="1685" alt="scannercli_test" src="https://user-images.githubusercontent.com/1322923/71978970-e3c47e80-321c-11ea-989e-818a688b96f5.png">

