### PR TITLE
fix(helm): Set the default value of scannerCLIShowWillNotFix to false

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -23,8 +23,8 @@ changelog:
   sort: asc
   filters:
     exclude:
-      - '^docs:'
-      - '^test:'
+      - '^docs'
+      - '^test'
 dockers:
   - image_templates:
       - "docker.io/aquasec/harbor-scanner-aqua:{{ .Version }}"

--- a/helm/harbor-scanner-aqua/templates/deployment.yaml
+++ b/helm/harbor-scanner-aqua/templates/deployment.yaml
@@ -87,7 +87,7 @@ spec:
             - name: "SCANNER_CLI_SHOW_NEGLIGIBLE"
               value: {{ .Values.scanner.aqua.scannerCLIShowNegligible | default true | quote }}
             - name: "SCANNER_CLI_SHOW_WILL_NOT_FIX"
-              value: {{ .Values.scanner.aqua.scannerCLIShowWillNotFix | default true | quote }}
+              value: {{ .Values.scanner.aqua.scannerCLIShowWillNotFix | default false | quote }}
             - name: "SCANNER_AQUA_REPORTS_DIR"
               value: {{ .Values.scanner.aqua.reportsDir | quote }}
             - name: "SCANNER_CLI_HIDE_BASE"


### PR DESCRIPTION
This is to align with the default settings in Go code & Aqua CSP scanner settings

Signed-off-by: Daniel Pacak <pacak.daniel@gmail.com>