### PR TITLE
feat: Allow registering images in Aqua console

### DIFF
--- a/README.md
+++ b/README.md
@@ -419,6 +419,7 @@ Configuration of the adapter is done via environment variables at startup.
 | `SCANNER_CLI_SHOW_NEGLIGIBLE`               | `true`   | The flag passed to `scannercli` to show negligible/unknown severity vulnerabilities |
 | `SCANNER_CLI_OVERRIDE_REGISTRY_CREDENTIALS` | `false`  | The flag to enable passing `--robot-username` and `--robot-password` flags to the `scannercli` executable binary |
 | `SCANNER_CLI_DIRECT_CC`                     | `false`  | The flag passed to `scannercli` to contact CyberCenter directly (rather than through the Aqua server) |
+| `SCANNER_CLI_REGISTER_IMAGES`               | `Never`  | The flag to determine whether images are registered in Aqua management console: `Never` - skips registration; `Compliant` - registers only compliant images; `Always` - registers compliant and non-compliant images. |
 | `SCANNER_STORE_REDIS_URL`                   | `redis://harbor-harbor-redis:6379` | The server URI for the Redis store            |
 | `SCANNER_STORE_REDIS_NAMESPACE`             | `harbor.scanner.aqua:store` | The namespace for keys in the Redis store            |
 | `SCANNER_STORE_REDIS_POOL_MAX_ACTIVE`       | `5`      | The max number of connections allocated by the pool for the Redis store |

--- a/helm/harbor-scanner-aqua/README.md
+++ b/helm/harbor-scanner-aqua/README.md
@@ -4,10 +4,14 @@ Aqua CSP Scanner as a plug-in vulnerability scanner in the Harbor registry.
 
 ## TL;DR;
 
+```
+$ helm repo add aqua https://helm.aquasec.com
+```
+
 ### Without TLS
 
 ```
-$ helm install harbor-scanner-aqua . \
+$ helm install harbor-scanner-aqua aqua/harbor-scanner-aqua \
     --namespace harbor \
     --set aqua.version=$AQUA_VERSION \
     --set aqua.registry.server=registry.aquasec.com \
@@ -31,7 +35,7 @@ $ helm install harbor-scanner-aqua . \
    ```
 2. Install the `harbor-scanner-aqua` chart:
    ```
-   $ helm install harbor-scanner-aqua . \
+   $ helm install harbor-scanner-aqua aqua/harbor-scanner-aqua \
        --namespace harbor \
        --set service.port=8443 \
        --set scanner.api.tlsEnabled=true \
@@ -55,13 +59,17 @@ This chart bootstraps a scanner adapter deployment on a [Kubernetes](http://kube
 
 - Kubernetes 1.12+
 - Helm 2.11+ or Helm 3+
+- Add Aqua chart repository:
+  ```
+  $ helm repo add aqua https://helm.aquasec.com
+  ```
 
 ## Installing the Chart
 
 To install the chart with the release name `my-release`:
 
 ```
-$ helm install my-release .
+$ helm install my-release aqua/harbor-scanner-aqua
 ```
 
 The command deploys scanner adapter on the Kubernetes cluster in the default configuration. The [Parameters](#parameters)
@@ -85,7 +93,7 @@ The following table lists the configurable parameters of the scanner adapter cha
 
 |              Parameter                  |                                Description                              |    Default     |
 |-----------------------------------------|-------------------------------------------------------------------------|----------------|
-| `aqua.version`                          | The version of Aqua CSP that the adapter operates against               | `4.6`          |
+| `aqua.version`                          | The version of Aqua CSP that the adapter operates against               | `5.0`          |
 | `aqua.registry.server`                  | Aqua Docker registry server                                             | `registry.aquasec.com` |
 | `aqua.registry.username`                | Aqua Docker registry username                                           | N/A            |
 | `aqua.registry.password`                | Aqua Docker registry password                                           | N/A            |
@@ -102,6 +110,7 @@ The following table lists the configurable parameters of the scanner adapter cha
 | `scanner.aqua.scannerCLIShowNegligible` | The flag passed to `scannercli` to show negligible/unknown severity vulnerabilities | `true` |
 | `scanner.aqua.scannerCLIOverrideRegistryCredentials` | The flag to enable passing `--robot-username` and `--robot-password` flags to the `scannercli` executable binary | `false` |
 | `scanner.aqua.scannerCLIDirectCC`       | The flag passed to `scannercli` to contact CyberCenter directly (rather than through the Aqua server) | `false` |
+| `scanner.aqua.scannerCLIRegisterImages` | The flag to determine whether images are registered in Aqua management console: `Never` - skips registration; `Compliant` - registers only compliant images; `Always` - registers compliant and non-compliant images. | `Never` |
 | `scanner.aqua.reportsDir`               | Directory to save temporary scan reports                                | `/var/lib/scanner/reports` |
 | `scanner.aqua.useImageTag`              | The flag to determine whether the image tag or digest is used in the image reference passed to `scannercli` | `false` |
 | `scanner.api.tlsEnabled`                | The flag to enable or disable TLS for HTTP                              | `true`         |
@@ -124,7 +133,7 @@ The above parameters map to the env variables defined in [harbor-scanner-aqua](h
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.
 
 ```
-$ helm install my-release . \
+$ helm install my-release aqua/harbor-scanner-aqua \
     --namespace my-namespace \
     --set scanner.aqua.username=$AQUA_CONSOLE_USERNAME \
     --set scanner.aqua.password=$AQUA_CONSOLE_PASSWORD

--- a/helm/harbor-scanner-aqua/templates/deployment.yaml
+++ b/helm/harbor-scanner-aqua/templates/deployment.yaml
@@ -91,6 +91,8 @@ spec:
               value: {{ .Values.scanner.aqua.scannerCLIOverrideRegistryCredentials | default false | quote }}
             - name: "SCANNER_CLI_DIRECT_CC"
               value: {{ .Values.scanner.aqua.scannerCLIDirectCC | default false | quote }}
+            - name: "SCANNER_CLI_REGISTER_IMAGES"
+              value: {{ .Values.scanner.aqua.scannerCLIRegisterImages | default "Never" | quote }}
             - name: "SCANNER_AQUA_USE_IMAGE_TAG"
               value: {{ .Values.scanner.aqua.useImageTag | default false | quote }}
             - name: "SCANNER_STORE_REDIS_URL"

--- a/helm/harbor-scanner-aqua/values.yaml
+++ b/helm/harbor-scanner-aqua/values.yaml
@@ -28,7 +28,7 @@ mainResources:
 
 aqua:
   ## version the version of Aqua CSP that the adapter operates against
-  version: 4.6
+  version: 5.0
   registry:
     ## server the Aqua Docker registry server
     server: "registry.aquasec.com"
@@ -81,6 +81,11 @@ scanner:
     scannerCLIOverrideRegistryCredentials: false
     ## scannerCLIDirectCC the flag passed to `scannercli` to contact CyberCenter directly (rather than through the Aqua server)
     scannerCLIDirectCC: false
+    ## scannerCLIRegisterImages the flag to determine whether images are registered in Aqua management console:
+    ## `Never` - skips registration
+    ## `Compliant` - registers only compliant images
+    ## `Always` - registers compliant and non-compliant images
+    scannerCLIRegisterImages: Never
   store:
     ## redisURL the server URI for the Redis store
     redisURL: "redis://harbor-harbor-redis:6379"

--- a/pkg/aqua/command.go
+++ b/pkg/aqua/command.go
@@ -85,6 +85,15 @@ func (c *command) Scan(imageRef ImageRef) (report ScanReport, err error) {
 		fmt.Sprintf("--jsonfile=%s", reportFile.Name()),
 	}
 
+	switch c.cfg.ScannerCLIRegisterImages {
+	case etc.Never:
+		// Do nothing
+	case etc.Always:
+		args = append(args, "--register")
+	case etc.Compliant:
+		args = append(args, "--register-compliant")
+	}
+
 	log.WithFields(log.Fields{"exec": executable, "args": args}).Debug("Running scannercli")
 
 	if c.cfg.ScannerCLIOverrideRegistryCredentials {

--- a/pkg/aqua/command_test.go
+++ b/pkg/aqua/command_test.go
@@ -30,6 +30,7 @@ func TestCommand_Scan(t *testing.T) {
 		ScannerCLIShowNegligible:              true,
 		ScannerCLIOverrideRegistryCredentials: true,
 		ScannerCLIDirectCC:                    true,
+		ScannerCLIRegisterImages:              etc.Compliant,
 	}
 
 	imageRef := ImageRef{
@@ -84,6 +85,7 @@ func TestCommand_Scan(t *testing.T) {
 				"--direct-cc=true",
 				"--show-negligible=true",
 				"--jsonfile=/var/lib/scanner/reports/aqua_scan_report_1234567890.json",
+				"--register-compliant",
 				"--robot-username=robotName",
 				"--robot-password=robotPassword",
 				"--password=ch@ng3me!",
@@ -122,6 +124,7 @@ func TestCommand_Scan(t *testing.T) {
 				"--direct-cc=true",
 				"--show-negligible=true",
 				"--jsonfile=/var/lib/scanner/reports/aqua_scan_report_1234567890.json",
+				"--register-compliant",
 				"--robot-username=robotName",
 				"--robot-password=robotPassword",
 				"--password=ch@ng3me!",

--- a/pkg/http/api/v1/handler.go
+++ b/pkg/http/api/v1/handler.go
@@ -221,6 +221,7 @@ func (h *handler) getMetadata(res http.ResponseWriter, _ *http.Request) {
 			"env.SCANNER_CLI_SHOW_NEGLIGIBLE":               strconv.FormatBool(h.config.AquaCSP.ScannerCLIShowNegligible),
 			"env.SCANNER_CLI_OVERRIDE_REGISTRY_CREDENTIALS": strconv.FormatBool(h.config.AquaCSP.ScannerCLIOverrideRegistryCredentials),
 			"env.SCANNER_CLI_DIRECT_CC":                     strconv.FormatBool(h.config.AquaCSP.ScannerCLIDirectCC),
+			"env.SCANNER_CLI_REGISTER_IMAGES":               string(h.config.AquaCSP.ScannerCLIRegisterImages),
 		},
 	}
 	h.WriteJSON(res, metadata, api.MimeTypeMetadata, http.StatusOK)

--- a/pkg/http/api/v1/handler_test.go
+++ b/pkg/http/api/v1/handler_test.go
@@ -64,8 +64,10 @@ func TestHandler(t *testing.T) {
     "env.SCANNER_AQUA_USE_IMAGE_TAG":    "true",
     "env.SCANNER_CLI_NO_VERIFY":         "false",
     "env.SCANNER_CLI_SHOW_NEGLIGIBLE":   "true",
-    "env.SCANNER_CLI_OVERRIDE_REGISTRY_CREDENTIALS": "false",
-    "env.SCANNER_CLI_DIRECT_CC": "false"
+    "env.SCANNER_CLI_DIRECT_CC":         "false",
+    "env.SCANNER_CLI_REGISTER_IMAGES":   "Never",
+
+    "env.SCANNER_CLI_OVERRIDE_REGISTRY_CREDENTIALS": "false"
   }
 }`, string(bodyBytes))
 	})


### PR DESCRIPTION
This commit adds new config env SCANNER_CLI_REGISTER_IMAGES.

The value of the env determines whether images are registered
in Aqua console: Never - skips registration; Compliant -
registers only compliant images; Always - registers compliant
and non-compliant images.

Resolves: #77

Signed-off-by: Daniel Pacak <pacak.daniel@gmail.com>