### PR TITLE
fix: rename the environment variable according the naming convention

### DIFF
--- a/pkg/etc/config.go
+++ b/pkg/etc/config.go
@@ -65,7 +65,7 @@ type AquaCSP struct {
 
 	ScannerCLIOverrideRegistryCredentials bool `env:"SCANNER_CLI_OVERRIDE_REGISTRY_CREDENTIALS" envDefault:"false"`
 
-	ReportDelete bool `env:"AQUA_REPORT_DELETE" envDefault:"true"`
+	ReportDelete bool `env:"SCANNER_AQUA_REPORT_DELETE" envDefault:"true"`
 }
 
 type RedisStore struct {

--- a/pkg/etc/config_test.go
+++ b/pkg/etc/config_test.go
@@ -84,6 +84,7 @@ func TestGetConfig(t *testing.T) {
 				"SCANNER_CLI_REGISTER_IMAGES":               "Compliant",
 				"SCANNER_CLI_OVERRIDE_REGISTRY_CREDENTIALS": "true",
 				"SCANNER_REDIS_URL":                         "redis://localhost:6379",
+				"SCANNER_AQUA_REPORT_DELETE":                "false",
 			},
 			expectedConfig: Config{
 				API: API{
@@ -105,7 +106,7 @@ func TestGetConfig(t *testing.T) {
 					ScannerCLIShowNegligible:              false,
 					ScannerCLIRegisterImages:              Compliant,
 					ScannerCLIOverrideRegistryCredentials: true,
-					ReportDelete:                          true,
+					ReportDelete:                          false,
 				},
 				RedisStore: RedisStore{
 					Namespace:  "harbor.scanner.aqua:store",


### PR DESCRIPTION
the variable should have followed the SCANNER_ naming convention.
so `AQUA_REPORT_DELETE` should be renamed `SCANNER_AQUA_REPORT_DELETE`.