### PR TITLE
fix: removed the incorrect format for token and password in helm

### DIFF
--- a/helm/harbor-scanner-aqua/templates/deployment.yaml
+++ b/helm/harbor-scanner-aqua/templates/deployment.yaml
@@ -80,7 +80,7 @@ spec:
             - name: "SCANNER_AQUA_TOKEN"
               valueFrom:
                 secretKeyRef:
-                  name: { { include "harbor-scanner-aqua.fullname" . } }
+                  name: {{ include "harbor-scanner-aqua.fullname" . }}
                   key: aqua_token
             - name: "SCANNER_AQUA_HOST"
               value: {{ .Values.scanner.aqua.host | quote }}

--- a/helm/harbor-scanner-aqua/templates/secret.yaml
+++ b/helm/harbor-scanner-aqua/templates/secret.yaml
@@ -7,5 +7,5 @@ metadata:
 type: Opaque
 data:
   aqua_username: {{ .Values.scanner.aqua.username | b64enc | quote }}
-  aqua_password: { { .Values.scanner.aqua.password | b64enc | quote } }
-  aqua_token: { { .Values.scanner.aqua.token | b64enc | quote } }
+  aqua_password: {{ .Values.scanner.aqua.password | b64enc | quote }}
+  aqua_token: {{ .Values.scanner.aqua.token | b64enc | quote }}


### PR DESCRIPTION
The formatting of values `SCANNER_AQUA_TOKEN` in deployment.yaml and aqua_password, aqua_token in secret.yaml was incorrect which was causing 

`error converting yaml to JSON`

After this fix, it is working.